### PR TITLE
Use rococo-westend system with bridges setup

### DIFF
--- a/bridges/modules/xcm-bridge/src/lib.rs
+++ b/bridges/modules/xcm-bridge/src/lib.rs
@@ -670,6 +670,11 @@ pub mod pallet {
 				.into()),
 			}
 		}
+
+		/// Get the bridge deposit amount required to open a new bridge.
+		pub fn bridge_deposit() -> BalanceOf<ThisChainOf<T, I>> {
+			T::BridgeDeposit::get()
+		}
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]

--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/testing/penpal/src/genesis.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/testing/penpal/src/genesis.rs
@@ -18,8 +18,6 @@ use frame_support::parameter_types;
 use sp_core::storage::Storage;
 use sp_keyring::Sr25519Keyring as Keyring;
 
-use xcm::latest::{prelude::*, ROCOCO_GENESIS_HASH, WESTEND_GENESIS_HASH};
-
 // Cumulus
 use emulated_integration_tests_common::{
 	accounts, build_genesis_storage, collators, SAFE_XCM_VERSION,
@@ -35,10 +33,6 @@ pub const USDT_ED: Balance = 70_000;
 parameter_types! {
 	pub PenpalSudoAccount: AccountId = Keyring::Alice.to_account_id();
 	pub PenpalAssetOwner: AccountId = PenpalSudoAccount::get();
-	pub WestendGlobalConsensusNetwork: NetworkId = NetworkId::ByGenesis(WESTEND_GENESIS_HASH);
-	pub PenpalAUniversalLocation: InteriorLocation = [GlobalConsensus(WestendGlobalConsensusNetwork::get()), Parachain(PARA_ID_A)].into();
-	pub RococoGlobalConsensusNetwork: NetworkId = NetworkId::ByGenesis(ROCOCO_GENESIS_HASH);
-	pub PenpalBUniversalLocation: InteriorLocation = [GlobalConsensus(RococoGlobalConsensusNetwork::get()), Parachain(PARA_ID_B)].into();
 }
 
 pub fn genesis(para_id: u32) -> Storage {

--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/testing/penpal/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/testing/penpal/src/lib.rs
@@ -15,7 +15,7 @@
 
 pub use penpal_runtime::{self, xcm_config::RelayNetworkId as PenpalRelayNetworkId};
 
-pub mod genesis;
+mod genesis;
 pub use genesis::{genesis, PenpalAssetOwner, PenpalSudoAccount, ED, PARA_ID_A, PARA_ID_B};
 
 // Substrate

--- a/cumulus/parachains/integration-tests/emulated/common/src/impls.rs
+++ b/cumulus/parachains/integration-tests/emulated/common/src/impls.rs
@@ -191,6 +191,11 @@ where
 
 		// collect messages from `OutboundMessages` for each active outbound lane in the source
 		for lane in active_outbound_lanes {
+			if OutboundLanes::<S, SI>::get(lane).is_none() {
+				// TODO: FAIL - investigate how was this created
+				continue;
+			}
+
 			let latest_generated_nonce =
 				OutboundLanes::<S, SI>::get(lane).unwrap().latest_generated_nonce;
 			let latest_received_nonce =

--- a/cumulus/parachains/integration-tests/emulated/networks/rococo-westend-system/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/networks/rococo-westend-system/src/lib.rs
@@ -73,23 +73,9 @@ decl_test_bridges! {
 	}
 }
 
-type AssetHubRococoRuntime = <AssetHubRococoPara as Chain>::Runtime;
-type AssetHubWestendRuntime = <AssetHubWestendPara as Chain>::Runtime;
 type BridgeHubRococoRuntime = <BridgeHubRococoPara as Chain>::Runtime;
 type BridgeHubWestendRuntime = <BridgeHubWestendPara as Chain>::Runtime;
 
-pub type AssetHubRococoWestendMessageHandler = BridgeMessagesHandler<
-	AssetHubRococoRuntime,
-	BridgeMessagesInstance1,
-	AssetHubWestendRuntime,
-	BridgeMessagesInstance1,
->;
-pub type AssetHubWestendRococoMessageHandler = BridgeMessagesHandler<
-	AssetHubWestendRuntime,
-	BridgeMessagesInstance1,
-	AssetHubRococoRuntime,
-	BridgeMessagesInstance1,
->;
 pub type RococoWestendMessageHandler = BridgeMessagesHandler<
 	BridgeHubRococoRuntime,
 	BridgeMessagesInstance3,

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/Cargo.toml
@@ -41,6 +41,7 @@ emulated-integration-tests-common = { workspace = true }
 parachains-common = { workspace = true, default-features = true }
 rococo-system-emulated-network = { workspace = true }
 westend-system-emulated-network = { workspace = true }
+rococo-westend-system-emulated-network = { workspace = true }
 
 # Bridge
 bp-asset-hub-westend = { workspace = true }

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/lib.rs
@@ -49,13 +49,6 @@ mod imports {
 		PenpalATeleportableAssetLocation, ASSETS_PALLET_ID, RESERVABLE_ASSET_ID, USDT_ID, XCM_V3,
 	};
 	pub use parachains_common::{AccountId, Balance};
-	pub use rococo_system_emulated_network::{
-		asset_hub_rococo_emulated_chain::{
-			genesis::{AssetHubRococoUniversalLocation, ED as ASSET_HUB_ROCOCO_ED},
-			AssetHubRococoParaPallet as AssetHubRococoPallet, AssetHubRococoRuntimeOrigin,
-		},
-		AssetHubRococoPara as AssetHubRococo, PenpalBPara as PenpalBRococo,
-	};
 	pub use westend_system_emulated_network::{
 		asset_hub_westend_emulated_chain::{
 			asset_hub_westend_runtime::{
@@ -67,11 +60,8 @@ mod imports {
 				AssetConversionOrigin as AssetHubWestendAssetConversionOrigin,
 				ExistentialDeposit as AssetHubWestendExistentialDeposit,
 			},
-			genesis::{
-				AssetHubWestendAssetOwner, AssetHubWestendUniversalLocation,
-				ED as ASSET_HUB_WESTEND_ED,
-			},
-			AssetHubWestendParaPallet as AssetHubWestendPallet, AssetHubWestendRuntimeOrigin,
+			genesis::{AssetHubWestendAssetOwner, ED as ASSET_HUB_WESTEND_ED},
+			AssetHubWestendParaPallet as AssetHubWestendPallet,
 		},
 		bridge_hub_westend_emulated_chain::{
 			bridge_hub_westend_runtime::xcm_config::{self as bhw_xcm_config},
@@ -80,7 +70,6 @@ mod imports {
 		collectives_westend_emulated_chain::CollectivesWestendParaPallet as CollectivesWestendPallet,
 		coretime_westend_emulated_chain::CoretimeWestendParaPallet as CoretimeWestendPallet,
 		penpal_emulated_chain::{
-			genesis::{PenpalAUniversalLocation, PenpalBUniversalLocation},
 			penpal_runtime::xcm_config::{
 				CustomizableAssetFromSystemAssetHub as PenpalCustomizableAssetFromSystemAssetHub,
 				LocalReservableFromAssetHub as PenpalLocalReservableFromAssetHub,

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/bridging.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/bridging.rs
@@ -13,7 +13,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::imports::*;
+use crate::imports::assert_ok;
+pub use codec::Encode;
+use emulated_integration_tests_common::{
+	xcm_emulator::{bx, Chain, Parachain as Para, TestExt},
+	xcm_helpers::xcm_transact_paid_execution,
+};
+use xcm::{
+	latest::{ROCOCO_GENESIS_HASH, WESTEND_GENESIS_HASH},
+	prelude::*,
+};
+
+// For a bridging we need rococo_westend system and not separated ones (because different Penpal setups).
+use rococo_westend_system_emulated_network::{
+	asset_hub_rococo_emulated_chain::{
+		asset_hub_rococo_runtime::ExistentialDeposit as AssetHubRococoExistentialDeposit,
+		genesis::AssetHubRococoUniversalLocation, AssetHubRococoParaPallet as AssetHubRococoPallet,
+		AssetHubRococoRuntimeOrigin,
+	},
+	asset_hub_westend_emulated_chain::{
+		asset_hub_westend_runtime::ExistentialDeposit as AssetHubWestendExistentialDeposit,
+		genesis::AssetHubWestendUniversalLocation,
+		AssetHubWestendParaPallet as AssetHubWestendPallet, AssetHubWestendRuntimeOrigin,
+	},
+	penpal_emulated_chain::{
+		PenpalAParaPallet as PenpalAPallet, PenpalBParaPallet as PenpalBPallet,
+	},
+	AssetHubRococoPara as AssetHubRococo, AssetHubWestendPara as AssetHubWestend,
+	PenpalAPara as PenpalA, PenpalBPara as PenpalB,
+};
 
 #[test]
 fn ah_to_ah_open_close_bridge_works() {
@@ -111,115 +139,124 @@ fn ah_to_ah_open_close_bridge_works() {
 
 #[test]
 fn para_to_para_open_close_bridge_works() {
-	let penpal_a_para_sovereign_account = AssetHubWestend::sovereign_account_id_of(
-		AssetHubWestend::sibling_location_of(PenpalA::para_id()),
+	// Ensure Penpal A/B locations (set `on_init` with `set_storage`).
+	let penpal_a_on_rococo_universal_location = PenpalA::execute_with(|| {
+		let loc = <<PenpalA as Chain>::Runtime as pallet_xcm::Config>::UniversalLocation::get();
+		assert_eq!(loc.global_consensus(), Ok(ByGenesis(ROCOCO_GENESIS_HASH)));
+		loc
+	});
+	let penpal_b_on_westend_universal_location = PenpalB::execute_with(|| {
+		let loc = <<PenpalB as Chain>::Runtime as pallet_xcm::Config>::UniversalLocation::get();
+		assert_eq!(loc.global_consensus(), Ok(ByGenesis(WESTEND_GENESIS_HASH)));
+		loc
+	});
+
+	// 1. Open bridge from PenpalA(Rococo) to PenpalB(Westend)
+	let penpal_a_para_sovereign_account = AssetHubRococo::sovereign_account_id_of(
+		AssetHubRococo::sibling_location_of(PenpalA::para_id()),
 	);
-	AssetHubWestend::fund_accounts(vec![(
+	let fee_amount = AssetHubRococoExistentialDeposit::get() * 1000;
+	let bridge_deposit = AssetHubRococo::ext_wrapper(|| {
+		<AssetHubRococo as AssetHubRococoPallet>::XcmOverAssetHubWestend::bridge_deposit()
+	});
+	AssetHubRococo::fund_accounts(vec![(
 		penpal_a_para_sovereign_account.clone().into(),
-		ASSET_HUB_WESTEND_ED * 10000000000, /* <- enough money for paid execution and for bridge
-		                                     * deposit */
+		AssetHubRococoExistentialDeposit::get() + fee_amount + bridge_deposit,
 	)]);
 
-	let fee_amount = ASSET_HUB_WESTEND_ED * 1000;
-	let system_asset = (Parent, fee_amount);
-
-	let call = bp_asset_hub_westend::Call::XcmOverAssetHubRococo(
-		bp_xcm_bridge::XcmBridgeCall::open_bridge {
-			bridge_destination_universal_location: Box::new(PenpalBUniversalLocation::get().into()),
-			maybe_notify: None,
-		},
-	)
-	.encode();
-
-	// wrap the call as paid execution
-	let xcm = xcm_transact_paid_execution(
-		call.into(),
-		OriginKind::Xcm,
-		system_asset.into(),
-		penpal_a_para_sovereign_account,
-	);
-	// send XCM from PenpalA to the AssetHubWestend
-	let system_para_destination = PenpalA::sibling_location_of(AssetHubWestend::para_id());
+	// send paid XCM with `open_bridge` from PenpalA to the AssetHubRococo
 	PenpalA::execute_with(|| {
-		let root_origin = <PenpalA as Chain>::RuntimeOrigin::root();
 		assert_ok!(<PenpalA as PenpalAPallet>::PolkadotXcm::send(
-			root_origin,
-			bx!(system_para_destination.into()),
-			bx!(xcm),
+			<PenpalA as Chain>::RuntimeOrigin::root(),
+			bx!(PenpalA::sibling_location_of(AssetHubRococo::para_id()).into()),
+			bx!(xcm_transact_paid_execution(
+				bp_asset_hub_rococo::Call::XcmOverAssetHubWestend(
+					bp_xcm_bridge::XcmBridgeCall::open_bridge {
+						bridge_destination_universal_location: Box::new(
+							penpal_b_on_westend_universal_location.into()
+						),
+						maybe_notify: None,
+					},
+				)
+				.encode()
+				.into(),
+				OriginKind::Xcm,
+				(Parent, fee_amount).into(),
+				penpal_a_para_sovereign_account,
+			)),
 		));
 
 		PenpalA::assert_xcm_pallet_sent();
 	});
 
-	let penpal_a_bridge_opened_lane_id = AssetHubWestend::execute_with(|| {
-		// check BridgeOpened event on AssetHubWestend
-		let events = AssetHubWestend::events();
-		type RuntimeEventWestend = <AssetHubWestend as Chain>::RuntimeEvent;
-		AssetHubWestend::assert_xcmp_queue_success(None);
-		events.iter().find_map(|event| {
-			if let RuntimeEventWestend::XcmOverAssetHubRococo(
-				pallet_xcm_bridge::Event::BridgeOpened { lane_id, .. },
-			) = event
+	// check BridgeOpened event on AssetHubRococo
+	let penpal_a_bridge_opened_lane_id = AssetHubRococo::execute_with(|| {
+		let events = AssetHubRococo::events();
+		type RuntimeEvent = <AssetHubRococo as Chain>::RuntimeEvent;
+		AssetHubRococo::assert_xcmp_queue_success(None);
+		let e = events.iter().find_map(|event| {
+			if let RuntimeEvent::XcmOverAssetHubWestend(pallet_xcm_bridge::Event::BridgeOpened {
+				lane_id,
+				..
+			}) = event
 			{
 				Some(*lane_id)
 			} else {
 				None
 			}
-		})
+		});
+		e
 	});
-
 	assert!(penpal_a_bridge_opened_lane_id.is_some(), "PenpalA BridgeOpened event not found");
 
-	let penpal_b_para_sovereign_account = AssetHubRococo::sovereign_account_id_of(
-		AssetHubRococo::sibling_location_of(PenpalBRococo::para_id()),
+	// 2. Open bridge from PenpalB(Westend) to PenpalA(Rococo)
+	let penpal_b_para_sovereign_account = AssetHubWestend::sovereign_account_id_of(
+		AssetHubWestend::sibling_location_of(PenpalB::para_id()),
 	);
-	AssetHubRococo::fund_accounts(vec![(
+	let fee_amount = AssetHubWestendExistentialDeposit::get() * 1000;
+	let bridge_deposit = AssetHubWestend::ext_wrapper(|| {
+		<AssetHubWestend as AssetHubWestendPallet>::XcmOverAssetHubRococo::bridge_deposit()
+	});
+	AssetHubWestend::fund_accounts(vec![(
 		penpal_b_para_sovereign_account.clone().into(),
-		ASSET_HUB_ROCOCO_ED * 10000000000, /* <- enough money for paid execution and for bridge
-		                                    * deposit */
+		AssetHubWestendExistentialDeposit::get() + fee_amount + bridge_deposit,
 	)]);
 
-	let fee_amount = ASSET_HUB_ROCOCO_ED * 1000;
-	let system_asset = (Parent, fee_amount);
+	// send paid XCM with `open_bridge` from PenpalB to the AssetHubWestend
+	PenpalB::execute_with(|| {
+		assert_ok!(<PenpalB as PenpalBPallet>::PolkadotXcm::send(
+			<PenpalB as Chain>::RuntimeOrigin::root(),
+			bx!(PenpalB::sibling_location_of(AssetHubWestend::para_id()).into()),
+			bx!(xcm_transact_paid_execution(
+				bp_asset_hub_westend::Call::XcmOverAssetHubRococo(
+					bp_xcm_bridge::XcmBridgeCall::open_bridge {
+						bridge_destination_universal_location: Box::new(
+							penpal_a_on_rococo_universal_location.into()
+						),
+						maybe_notify: None,
+					},
+				)
+				.encode()
+				.into(),
+				OriginKind::Xcm,
+				(Parent, fee_amount).into(),
+				penpal_b_para_sovereign_account,
+			)),
+		));
 
-	let call = bp_asset_hub_rococo::Call::XcmOverAssetHubWestend(
-		bp_xcm_bridge::XcmBridgeCall::open_bridge {
-			bridge_destination_universal_location: Box::new(PenpalAUniversalLocation::get().into()),
-			maybe_notify: None,
-		},
-	)
-	.encode();
-
-	// wrap the call as paid execution
-	let xcm = xcm_transact_paid_execution(
-		call.into(),
-		OriginKind::Xcm,
-		system_asset.into(),
-		penpal_b_para_sovereign_account,
-	);
-	// send XCM from PenpalBRococo to the AssetHubRococo
-	let system_para_destination = PenpalBRococo::sibling_location_of(AssetHubRococo::para_id());
-	PenpalBRococo::execute_with(|| {
-		let root_origin = <PenpalBRococo as Chain>::RuntimeOrigin::root();
-		let sent = <PenpalBRococo as PenpalBPallet>::PolkadotXcm::send(
-			root_origin,
-			bx!(system_para_destination.into()),
-			bx!(xcm),
-		);
-		assert_ok!(sent);
-
-		PenpalBRococo::assert_xcm_pallet_sent();
+		PenpalB::assert_xcm_pallet_sent();
 	});
 
-	let penpal_b_bridge_opened_lane_id = AssetHubRococo::execute_with(|| {
-		// check BridgeOpened event on AssetHubRococo
-		let events = AssetHubRococo::events();
-		type RuntimeEventRococo = <AssetHubRococo as Chain>::RuntimeEvent;
-		AssetHubRococo::assert_xcmp_queue_success(None);
+	// check BridgeOpened event on AssetHubWestend
+	let penpal_b_bridge_opened_lane_id = AssetHubWestend::execute_with(|| {
+		let events = AssetHubWestend::events();
+		type RuntimeEvent = <AssetHubWestend as Chain>::RuntimeEvent;
+		AssetHubWestend::assert_xcmp_queue_success(None);
 		events.iter().find_map(|event| {
-			if let RuntimeEventRococo::XcmOverAssetHubWestend(
-				pallet_xcm_bridge::Event::BridgeOpened { lane_id, .. },
-			) = event
+			if let RuntimeEvent::XcmOverAssetHubRococo(pallet_xcm_bridge::Event::BridgeOpened {
+				lane_id,
+				..
+			}) = event
 			{
 				Some(*lane_id)
 			} else {
@@ -227,8 +264,8 @@ fn para_to_para_open_close_bridge_works() {
 			}
 		})
 	});
-
 	assert!(penpal_b_bridge_opened_lane_id.is_some(), "PenpalB BridgeOpened event not found");
 
+	// check the same lane ID is generated
 	assert_eq!(penpal_a_bridge_opened_lane_id, penpal_b_bridge_opened_lane_id);
 }


### PR DESCRIPTION
I found the reason why Penpal were switched for https://github.com/paritytech/polkadot-sdk/pull/8519

```
// For a bridging we need rococo_westend system and not separated ones (because different Penpal setups).
use rococo_westend_system_emulated_network::{
```